### PR TITLE
make "npm start" work for both node 16 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-error-overlay": "6.0.9"
   },
   "scripts": {
-    "start": "ionic serve",
+    "start": "ionic serve --host=127.0.0.1",
     "build": "ionic build",
     "test": "craco test",
     "eject": "react-scripts eject"

--- a/set-env.sh
+++ b/set-env.sh
@@ -1,5 +1,8 @@
+#!/bin/bash
 
-#set the correct JAVA_HOME and ANDROID_SDK_ROOT for your computer
+# how-to-use "source ./set-env.sh" or ". ./set-env.sh"
+
+# set the correct JAVA_HOME and ANDROID_SDK_ROOT for your computer
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_311.jdk/Contents/Home/
 export ANDROID_SDK_ROOT=/Users/mchin/Library/Android/sdk
 
@@ -14,4 +17,16 @@ export SKIP_PREFLIGHT_CHECK=true
 # Workaround for bug in source-map for Node v18
 # See: https://github.com/gatsbyjs/gatsby/issues/35607#issuecomment-1122762324
 # & https://github.com/parcel-bundler/parcel/issues/8005#issuecomment-1120149358
-export NODE_OPTIONS=--no-experimental-fetch
+node_version="$(nvm version)"
+if [[ "$node_version" == "v18."* ]]; then
+  export NODE_OPTIONS="--no-experimental-fetch --openssl-legacy-provider"
+else
+  unset NODE_OPTIONS
+fi
+
+# if you want to run "nvm version" in a shell script, you need to "source" nvm.sh like below
+# the nvm is a shell function, run "type -a nvm" for details
+# . /usr/local/opt/nvm/nvm.sh
+# nvm_version
+# printf "$(nvm version)"
+


### PR DESCRIPTION
* append --host=127.0.0.1 to 'ionic serve' in package.json

* change set-env.sh to set node 18 options for node 18 only

Please review the changes and make sure they don't break your dev env. After review, please "squash and merge" this PR. I would like keep the commit history on main branch clean. Thanks.