### PR TITLE
Migrated to Recoil state management library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,12 @@
     "": {
       "name": "gplates-in-schools",
       "version": "0.0.1",
+      "bundleDependencies": [
+        "ionicons/icons"
+      ],
       "dependencies": {
+        "@awesome-cordova-plugins/app-preferences": "^5.44.0",
+        "@awesome-cordova-plugins/core": "^5.44.0",
         "@awesome-cordova-plugins/social-sharing": "^5.44.0",
         "@capacitor-community/media": "^3.0.0",
         "@capacitor-community/sqlite": "^3.5.1-1",
@@ -26,6 +31,7 @@
         "@ionic/react": "^6.1.4",
         "@ionic/react-router": "^6.1.4",
         "cesium": "^1.93.0",
+        "cordova-plugin-app-preferences": "^0.99.3",
         "cordova-plugin-x-socialsharing": "^6.0.3",
         "html2canvas": "^1.4.1",
         "react": "^18.1.0",
@@ -34,6 +40,7 @@
         "react-router-dom": "^5.3.1",
         "react-sqlite-hook": "^2.1.12",
         "react-transition-group": "^4.4.2",
+        "recoil": "^0.7.4",
         "sass": "^1.51.0",
         "swiper": "^8.1.4",
         "typescript": "^4.6.4",
@@ -94,11 +101,22 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@awesome-cordova-plugins/app-preferences": {
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/app-preferences/-/app-preferences-5.44.0.tgz",
+      "integrity": "sha512-MttfSS9NcLJ/0WW7bYzyZ07c+tqenDzuw1FYd1r9Kl6Tjyw8Ys6/47luZNJq7vlBu2yd1OpbumCPpcGY09RyKQ==",
+      "dependencies": {
+        "@types/cordova": "latest"
+      },
+      "peerDependencies": {
+        "@awesome-cordova-plugins/core": "^5.1.0",
+        "rxjs": "^5.5.0 || ^6.5.0 || ^7.3.0"
+      }
+    },
     "node_modules/@awesome-cordova-plugins/core": {
       "version": "5.44.0",
       "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.44.0.tgz",
       "integrity": "sha512-LFa0RQyKoiMoh8GiFTOUh+SHdxs6XiozCAzOqq0YUrAAGb/sQRwZ+pDtqw0RTSQqN7DV3FH8ayeuHX8LEm3bNA==",
-      "peer": true,
       "dependencies": {
         "@types/cordova": "latest"
       },
@@ -5127,6 +5145,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -7021,6 +7050,14 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/cordova-plugin-app-preferences": {
+      "version": "0.99.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-app-preferences/-/cordova-plugin-app-preferences-0.99.3.tgz",
+      "integrity": "sha512-pd9qVp2zorLvWZZepa7Zsq0V61I/jar1WsarJJ+tTMBOFhhdDLf9Bp5dAopnHhLfDckrSqz7kqXSRlzasOm3eA==",
+      "bin": {
+        "cordova-app-preferences-generator": "bin/build-app-settings.js"
       }
     },
     "node_modules/cordova-plugin-x-socialsharing": {
@@ -10582,6 +10619,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -18109,6 +18151,25 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -21403,9 +21464,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23779,11 +23842,18 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
+    "@awesome-cordova-plugins/app-preferences": {
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/app-preferences/-/app-preferences-5.44.0.tgz",
+      "integrity": "sha512-MttfSS9NcLJ/0WW7bYzyZ07c+tqenDzuw1FYd1r9Kl6Tjyw8Ys6/47luZNJq7vlBu2yd1OpbumCPpcGY09RyKQ==",
+      "requires": {
+        "@types/cordova": "latest"
+      }
+    },
     "@awesome-cordova-plugins/core": {
       "version": "5.44.0",
       "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.44.0.tgz",
       "integrity": "sha512-LFa0RQyKoiMoh8GiFTOUh+SHdxs6XiozCAzOqq0YUrAAGb/sQRwZ+pDtqw0RTSQqN7DV3FH8ayeuHX8LEm3bNA==",
-      "peer": true,
       "requires": {
         "@types/cordova": "latest"
       }
@@ -27440,6 +27510,13 @@
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "requires": {
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+        }
       }
     },
     "ansi-html": {
@@ -28932,6 +29009,11 @@
         "serialize-javascript": "^4.0.0",
         "webpack-log": "^2.0.0"
       }
+    },
+    "cordova-plugin-app-preferences": {
+      "version": "0.99.3",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-app-preferences/-/cordova-plugin-app-preferences-0.99.3.tgz",
+      "integrity": "sha512-pd9qVp2zorLvWZZepa7Zsq0V61I/jar1WsarJJ+tTMBOFhhdDLf9Bp5dAopnHhLfDckrSqz7kqXSRlzasOm3eA=="
     },
     "cordova-plugin-x-socialsharing": {
       "version": "6.0.3",
@@ -31666,6 +31748,11 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
+    },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -36349,7 +36436,7 @@
         "open": "^7.0.2",
         "pkg-up": "3.1.0",
         "prompts": "2.4.0",
-        "react-error-overlay": "^6.0.9",
+        "react-error-overlay": "6.0.9",
         "recursive-readdir": "2.2.2",
         "shell-quote": "1.7.2",
         "strip-ansi": "6.0.0",
@@ -37437,6 +37524,14 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "recursive-readdir": {
@@ -40026,9 +40121,11 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@awesome-cordova-plugins/app-preferences": "^5.44.0",
+    "@awesome-cordova-plugins/core": "^5.44.0",
     "@awesome-cordova-plugins/social-sharing": "^5.44.0",
     "@capacitor-community/media": "^3.0.0",
     "@capacitor-community/sqlite": "^3.5.1-1",
@@ -21,6 +23,7 @@
     "@ionic/react": "^6.1.4",
     "@ionic/react-router": "^6.1.4",
     "cesium": "^1.93.0",
+    "cordova-plugin-app-preferences": "^0.99.3",
     "cordova-plugin-x-socialsharing": "^6.0.3",
     "html2canvas": "^1.4.1",
     "react": "^18.1.0",
@@ -29,6 +32,7 @@
     "react-router-dom": "^5.3.1",
     "react-sqlite-hook": "^2.1.12",
     "react-transition-group": "^4.4.2",
+    "recoil": "^0.7.4",
     "sass": "^1.51.0",
     "swiper": "^8.1.4",
     "typescript": "^4.6.4",
@@ -110,5 +114,8 @@
   "bundledDependencies": [
     "ionicons/icons"
   ],
-  "description": "An Ionic project"
+  "description": "An Ionic project",
+  "bundleDependencies": [
+    "ionicons/icons"
+  ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import '@ionic/react/css/display.css'
 
 /* Theme variables */
 import './theme/variables.css'
+import { RecoilRoot } from 'recoil'
 
 // Singleton SQLite Hook
 export let sqlite: SQLiteHook
@@ -37,7 +38,9 @@ const App: React.FC = () => {
       <IonReactRouter>
         <IonRouterOutlet>
           <Route exact path="/main">
-            <Main />
+            <RecoilRoot>
+              <Main />
+            </RecoilRoot>
           </Route>
           <Route exact path="/">
             <Redirect to="/main" />

--- a/src/components/AgeSlider.tsx
+++ b/src/components/AgeSlider.tsx
@@ -17,27 +17,28 @@ import {
   playForwardOutline,
   timeOutline,
 } from 'ionicons/icons'
-import React, { Dispatch, SetStateAction, useState } from 'react'
+import React, { useState } from 'react'
 import { setNumber } from '../functions/input'
 import { AnimationService } from '../functions/animation'
+import { LIMIT_LOWER, LIMIT_UPPER } from '../functions/atoms'
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil'
+import {
+  age,
+  animatePlaying,
+  isSettingsMenuShow,
+  settingsPath,
+} from '../functions/atoms'
 
 interface AgeSliderProps {
   buttons: any
   animationService: AnimationService
-  minAge: number
-  maxAge: number
-  setMenuPath: Dispatch<SetStateAction<string>>
-  setMenuState: Dispatch<SetStateAction<boolean>>
 }
 
-const AgeSlider: React.FC<AgeSliderProps> = ({
-  buttons,
-  animationService,
-  minAge,
-  maxAge,
-  setMenuPath,
-  setMenuState,
-}) => {
+const AgeSlider: React.FC<AgeSliderProps> = ({ buttons, animationService }) => {
+  const [_age, setAge] = useRecoilState(age)
+  const playing = useRecoilValue(animatePlaying)
+  const setMenuPath = useSetRecoilState(settingsPath)
+  const setMenuState = useSetRecoilState(isSettingsMenuShow)
   const [hidden, setHidden] = useState(true)
 
   const openMenu = () => {
@@ -52,12 +53,12 @@ const AgeSlider: React.FC<AgeSliderProps> = ({
           <IonLabel>Time:</IonLabel>
           <IonInput
             inputMode="numeric"
-            min={minAge}
-            max={maxAge}
+            min={LIMIT_LOWER}
+            max={LIMIT_UPPER}
             onIonChange={(e) =>
-              setNumber(animationService.setAge, e.detail.value, minAge, maxAge)
+              setNumber(setAge, e.detail.value, LIMIT_LOWER, LIMIT_UPPER)
             }
-            value={animationService.age}
+            value={_age}
           />
           Ma
         </IonItem>
@@ -65,14 +66,10 @@ const AgeSlider: React.FC<AgeSliderProps> = ({
           <div>
             <IonButton
               fill="clear"
-              onClick={() =>
-                animationService.setPlaying(!animationService.playing)
-              }
+              onClick={() => animationService.setPlaying(!playing)}
               size="default"
             >
-              <IonIcon
-                icon={animationService.playing ? pauseOutline : playOutline}
-              />
+              <IonIcon icon={playing ? pauseOutline : playOutline} />
             </IonButton>
             <IonButton
               fill="clear"
@@ -111,12 +108,10 @@ const AgeSlider: React.FC<AgeSliderProps> = ({
               animationService.setDragging(false)
               animationService.onAgeSliderChange(e.detail.value as number)
             }}
-            min={minAge}
-            max={maxAge}
-            onIonChange={(e) =>
-              animationService.setAge(e.detail.value as number)
-            }
-            value={animationService.age}
+            min={LIMIT_LOWER}
+            max={LIMIT_UPPER}
+            onIonChange={(e) => setAge(e.detail.value as number)}
+            value={_age}
           />
         </IonItem>
       </div>
@@ -130,7 +125,7 @@ const AgeSlider: React.FC<AgeSliderProps> = ({
             setHidden(!hidden)
           }}
         >
-          {animationService.age} Ma
+          {_age} Ma
         </div>
         <div>
           {buttons}

--- a/src/components/BackgroundColorSettings.tsx
+++ b/src/components/BackgroundColorSettings.tsx
@@ -1,8 +1,14 @@
-import { IonItem, IonItemDivider, IonLabel, IonToggle } from '@ionic/react'
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { IonItem, IonLabel, IonToggle } from '@ionic/react'
+import React, { useEffect } from 'react'
 import { RgbColorPicker } from 'react-colorful'
 import { Viewer } from 'cesium'
 import * as Cesium from 'cesium'
+import { useRecoilState } from 'recoil'
+import {
+  backgroundColor,
+  backgroundIsCustom,
+  backgroundIsStarry,
+} from '../functions/atoms'
 
 const defaultBackground = () => {
   return new Cesium.SkyBox({
@@ -19,28 +25,22 @@ const defaultBackground = () => {
 
 interface ContainerProps {
   viewer: Viewer
-  backgroundSetting: any
+  isBackgroundSettingEnable: any
+  setIsBackgroundSettingEnable: any
 }
 
 export const BackgroundColorSettings: React.FC<ContainerProps> = ({
   viewer,
-  backgroundSetting,
+  isBackgroundSettingEnable,
+  setIsBackgroundSettingEnable,
 }) => {
-  const isBackgroundSettingEnable = backgroundSetting.isBackgroundSettingEnable
-  const setIsBackgroundSettingEnable =
-    backgroundSetting.setIsBackgroundSettingEnable
-
-  const isStarryBackgroundEnable = backgroundSetting.isStarryBackgroundEnable
-  const setIsStarryBackgroundEnable =
-    backgroundSetting.setIsStarryBackgroundEnable
-
-  const isCustomisedColorBackgroundEnable =
-    backgroundSetting.isCustomisedColorBackgroundEnable
-  const setIsCustomisedColorBackgroundEnable =
-    backgroundSetting.setIsCustomisedColorBackgroundEnable
-
-  const color = backgroundSetting.color
-  const setColor = backgroundSetting.setColor
+  const [isStarryBackgroundEnable, setIsStarryBackgroundEnable] =
+    useRecoilState(backgroundIsStarry)
+  const [
+    isCustomisedColorBackgroundEnable,
+    setIsCustomisedColorBackgroundEnable,
+  ] = useRecoilState(backgroundIsCustom)
+  const [color, setColor] = useRecoilState(backgroundColor)
 
   const setDefaultBackground = (viewer: Viewer) => {
     viewer.scene.skyBox = defaultBackground()

--- a/src/components/RasterMenu.tsx
+++ b/src/components/RasterMenu.tsx
@@ -11,6 +11,8 @@ import {
 import './RasterMenu.scss'
 import { chevronBack, chevronForward } from 'ionicons/icons'
 import { rasterData } from '../functions/DataLoader'
+import { useRecoilState } from 'recoil'
+import { isRasterMenuShow } from '../functions/atoms'
 
 const rasterMaps = [
   {
@@ -58,8 +60,6 @@ const rasterMaps = [
 ]
 
 interface ContainerProps {
-  isShow: boolean
-  closeWindow: Function
   addLayer: Function
   isViewerLoading: Function
 }
@@ -77,12 +77,11 @@ const delay = (ms: number) => {
 }
 
 export const RasterMenu: React.FC<ContainerProps> = ({
-  isShow,
-  closeWindow,
   addLayer,
   isViewerLoading,
 }) => {
   const [isSelectedList, setIsSelectedList] = useState(initialSelection())
+  const [isShow, setIsShow] = useRecoilState(isRasterMenuShow)
   const [present, dismiss] = useIonLoading()
 
   let optionList = []
@@ -134,7 +133,7 @@ export const RasterMenu: React.FC<ContainerProps> = ({
       <div
         className={'raster-menu-backdrop'}
         onClick={() => {
-          closeWindow()
+          setIsShow(false)
         }}
       />
       <div className={'raster-menu-scroll'}>{optionList}</div>

--- a/src/components/SocialSharing.tsx
+++ b/src/components/SocialSharing.tsx
@@ -5,9 +5,8 @@ import assert from 'assert'
 import { timeout } from 'workbox-core/_private'
 import { Media } from '@capacitor-community/media'
 import { getPlatforms, isPlatform } from '@ionic/react'
-import { Filesystem, Directory, Encoding } from '@capacitor/filesystem'
+import { Filesystem, Directory } from '@capacitor/filesystem'
 import { SocialSharing as ShareTool } from '@awesome-cordova-plugins/social-sharing'
-import { IonButton, useIonLoading } from '@ionic/react'
 import React from 'react'
 
 const getCesiumScreenShotBlob = async (viewer: Viewer) => {

--- a/src/components/StarrySky.tsx
+++ b/src/components/StarrySky.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react'
 import assert from 'assert'
+import { useRecoilState } from 'recoil'
+import { backgroundIsStarry } from '../functions/atoms'
 
 let maxStars = 300
 
@@ -78,14 +80,12 @@ class Star {
   }
 }
 
-interface ContainerProps {
-  isStarryBackgroundEnable: boolean
-}
+interface ContainerProps {}
 
-export const StarrySky: React.FC<ContainerProps> = ({
-  isStarryBackgroundEnable,
-}) => {
+export const StarrySky: React.FC<ContainerProps> = () => {
   Star.maxStars = maxStars
+
+  const [isStarryBackgroundEnable, _] = useRecoilState(backgroundIsStarry)
 
   useEffect(() => {
     if (!isStarryBackgroundEnable) return () => {} // if not enabled, do nothing and return

--- a/src/components/VectorDataLayerMenu.tsx
+++ b/src/components/VectorDataLayerMenu.tsx
@@ -13,12 +13,12 @@ import {
 } from '@ionic/react'
 import { vectorData } from '../functions/DataLoader'
 import React from 'react'
-import { WebMapTileServiceImageryProvider } from 'cesium'
 import { timeout } from 'workbox-core/_private'
+import { useRecoilState } from 'recoil'
+import { isVectorMenuShow } from '../functions/atoms'
+import { WebMapTileServiceImageryProvider } from 'cesium'
 
 interface ContainerProps {
-  isShow: boolean
-  closeModal: Function
   checkedVectorData: { [key: string]: WebMapTileServiceImageryProvider }
   setVectorData: Function
   addLayer: Function
@@ -27,14 +27,13 @@ interface ContainerProps {
 }
 
 export const VectorDataLayerMenu: React.FC<ContainerProps> = ({
-  isShow,
-  closeModal,
   checkedVectorData,
   setVectorData,
   addLayer,
   removeLayer,
   isViewerLoading,
 }) => {
+  const [isShow, setIsShow] = useRecoilState(isVectorMenuShow)
   const [present, dismiss] = useIonLoading()
 
   const waitUntilLoaded = async () => {
@@ -76,7 +75,7 @@ export const VectorDataLayerMenu: React.FC<ContainerProps> = ({
               await present({ message: 'Please Wait...' })
               await waitUntilLoaded()
               await dismiss()
-              closeModal()
+              setIsShow(false)
             }}
             color={'secondary'}
           >

--- a/src/functions/animation.ts
+++ b/src/functions/animation.ts
@@ -1,6 +1,7 @@
 import { SingleTileImageryProvider, Viewer } from 'cesium'
 import { CachingService } from './cache'
-import { Dispatch, SetStateAction } from 'react'
+import { SetterOrUpdater } from 'recoil'
+import { GEOSRV_URL, LIMIT_LOWER, LIMIT_UPPER } from './atoms'
 
 let animateFrame = 0
 let animateNext = false
@@ -11,22 +12,18 @@ let dragging = false
 export class AnimationService {
   constructor(
     public cachingService: CachingService,
-    public viewer: Viewer,
-    public age: number,
-    public setAge: Dispatch<SetStateAction<number>>,
+    public setAge: SetterOrUpdater<number>,
     public exact: boolean,
-    public setExact: Dispatch<SetStateAction<boolean>>,
+    public setExact: SetterOrUpdater<boolean>,
     public fps: number,
     public increment: number,
-    public limitLower: number,
-    public limitUpper: number,
     public loop: boolean,
-    public setLoop: Dispatch<SetStateAction<boolean>>,
+    public setLoop: SetterOrUpdater<boolean>,
     public playing: boolean,
-    public _setPlaying: Dispatch<SetStateAction<boolean>>,
+    public _setPlaying: SetterOrUpdater<boolean>,
     public range: { lower: number; upper: number },
-    public setRange: Dispatch<SetStateAction<{ lower: number; upper: number }>>,
-    public URL: string
+    public setRange: SetterOrUpdater<{ lower: number; upper: number }>,
+    public viewer: Viewer
   ) {}
 
   drawFrame = async (url: string, force = false) => {
@@ -94,22 +91,22 @@ export class AnimationService {
 
   onAgeSliderChange = (value: number) => {
     animateFrame = value
-    this.drawFrame(this.URL, true)
+    this.drawFrame(GEOSRV_URL, true)
   }
 
   resetPlayHead = () => {
     this.setPlaying(false)
     animateFrame = this.range.lower
-    this.drawFrame(this.URL, true)
+    this.drawFrame(GEOSRV_URL, true)
   }
 
   movePlayHead = (value: number) => {
     this.setPlaying(false)
     animateFrame = Math.min(
-      Math.max(animateFrame + value, this.limitLower),
-      this.limitUpper
+      Math.max(animateFrame + value, LIMIT_LOWER),
+      LIMIT_UPPER
     )
-    this.drawFrame(this.URL, true)
+    this.drawFrame(GEOSRV_URL, true)
   }
 
   setDragging = (value: boolean) => {
@@ -148,7 +145,7 @@ export class AnimationService {
         animateFrame = this.range.lower
       }
 
-      this.scheduleFrame(this.URL)
+      this.scheduleFrame(GEOSRV_URL)
     } else {
       clearTimeout(animateTimeout)
     }

--- a/src/functions/atoms.tsx
+++ b/src/functions/atoms.tsx
@@ -1,0 +1,51 @@
+import { atom } from 'recoil'
+
+// TODO: Dynamically assign these variables based on selected raster
+export const GEOSRV_URL =
+  'https://geosrv.earthbyte.org/geoserver/Lithodat/wms?service=WMS&version=1.1.0&request=GetMap&layers=Lithodat%3Acontinental_polygons_{count}Ma&bbox=-180.0%2C-90.0%2C180.0%2C90.0&width=768&height=384&srs=EPSG%3A4326&styles=&format=image%2Fpng%3B%20mode%3D8bit'
+export const LIMIT_UPPER = 410
+export const LIMIT_LOWER = 0
+
+export const age = atom({ key: 'age', default: 0 })
+export const animateExact = atom({ key: 'animateExact', default: false })
+export const animateFps = atom({ key: 'animateFps', default: 10 })
+export const animateIncrement = atom({ key: 'animateIncrement', default: 1 })
+export const animateLoop = atom({ key: 'animateLoop', default: false })
+export const animatePlaying = atom({ key: 'animatePlaying', default: false })
+export const animateRange = atom({
+  key: 'animateRange',
+  default: {
+    lower: LIMIT_LOWER,
+    upper: LIMIT_UPPER,
+  },
+})
+
+export const backgroundColor = atom({
+  key: 'backgroundColor',
+  default: { r: 255, g: 255, b: 255 },
+})
+export const backgroundIsStarry = atom({
+  key: 'backgroundIsStarry',
+  default: false,
+})
+export const backgroundIsCustom = atom({
+  key: 'backgroundIsCustom',
+  default: false,
+})
+
+export const isAboutPageShow = atom({ key: 'isAboutPageShow', default: false })
+export const isRasterMenuShow = atom({
+  key: 'isRasterMenuShow',
+  default: false,
+})
+export const isSettingsMenuShow = atom({
+  key: 'isSettingsMenuShow',
+  default: false,
+})
+export const isVectorMenuShow = atom({
+  key: 'isVectorMenuShow',
+  default: false,
+})
+
+// Settings menu path: Ionic's Nav component is not available under React yet, so we have to build our own solution
+export const settingsPath = atom({ key: 'settingsPath', default: 'root' })

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -13,10 +13,9 @@ import './AboutPage.scss'
 import { Browser } from '@capacitor/browser'
 
 import { Share } from '@capacitor/share'
-interface ContainerProps {
-  isShow: boolean
-  closeModal: Function
-}
+import { useRecoilState } from 'recoil'
+import { isAboutPageShow } from '../functions/atoms'
+interface ContainerProps {}
 
 const sentEmail = async (email: string) => {
   await Share.share({
@@ -25,7 +24,9 @@ const sentEmail = async (email: string) => {
   })
 }
 
-export const AboutPage: React.FC<ContainerProps> = ({ isShow, closeModal }) => {
+export const AboutPage: React.FC<ContainerProps> = () => {
+  const [isShow, setIsShow] = useRecoilState(isAboutPageShow)
+
   return (
     <IonModal isOpen={isShow} animated backdropDismiss={false}>
       <IonToolbar>
@@ -33,7 +34,7 @@ export const AboutPage: React.FC<ContainerProps> = ({ isShow, closeModal }) => {
         <IonButtons slot={'end'}>
           <IonButton
             onClick={() => {
-              closeModal()
+              setIsShow(false)
             }}
             color={'secondary'}
           >

--- a/src/pages/SettingMenuPage.tsx
+++ b/src/pages/SettingMenuPage.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import './SettingMenuPage.scss'
 import {
   IonModal,
@@ -29,75 +29,56 @@ import { chevronBack, chevronForward } from 'ionicons/icons'
 import { CSSTransition } from 'react-transition-group'
 import { BackgroundColorSettings } from '../components/BackgroundColorSettings'
 import { Viewer } from 'cesium'
+import { useRecoilState } from 'recoil'
+import {
+  animateExact,
+  animateFps,
+  animateIncrement,
+  animateLoop,
+  animateRange,
+  isSettingsMenuShow,
+  settingsPath,
+} from '../functions/atoms'
+import { LIMIT_LOWER, LIMIT_UPPER } from '../functions/atoms'
 
 interface ContainerProps {
-  animateExact: boolean
-  setAnimateExact: Dispatch<SetStateAction<boolean>>
-  animateLoop: boolean
-  setAnimateLoop: Dispatch<SetStateAction<boolean>>
-  animateRange: { lower: number; upper: number }
-  setAnimateRange: Dispatch<SetStateAction<{ lower: number; upper: number }>>
-  fps: number
-  setFps: Dispatch<SetStateAction<number>>
-  increment: number
-  setIncrement: Dispatch<SetStateAction<number>>
-  minAge: number
-  maxAge: number
-  closeModal: Function
-  isShow: boolean
-  path: string
-  setPath: Dispatch<SetStateAction<string>>
   viewer: Viewer
-  isStarryBackgroundEnable: boolean
-  setIsStarryBackgroundEnable: Dispatch<SetStateAction<boolean>>
 }
 
 // main component for setting menu
-export const SettingMenuPage: React.FC<ContainerProps> = ({
-  animateExact,
-  setAnimateExact,
-  animateLoop,
-  setAnimateLoop,
-  animateRange,
-  setAnimateRange,
-  fps,
-  setFps,
-  increment,
-  setIncrement,
-  minAge,
-  maxAge,
-  closeModal,
-  isShow,
-  path,
-  setPath,
-  viewer,
-  isStarryBackgroundEnable,
-  setIsStarryBackgroundEnable,
-}) => {
+export const SettingMenuPage: React.FC<ContainerProps> = ({ viewer }) => {
   const titles: { [key: string]: string } = {
     root: 'Settings Menu',
     animation: 'Animation Settings',
   }
 
-  // Animation Settings
+  const [exact, setExact] = useRecoilState(animateExact)
+  const [fps, setFps] = useRecoilState(animateFps)
+  const [increment, setIncrement] = useRecoilState(animateIncrement)
+  const [loop, setLoop] = useRecoilState(animateLoop)
+  const [path, setPath] = useRecoilState(settingsPath)
+  const [range, setRange] = useRecoilState(animateRange)
+  const [isShow, setIsShow] = useRecoilState(isSettingsMenuShow)
+
+  // Animation constants
   const minIncrement = 1
   const maxIncrement = 100
   const minFps = 1
   const maxFps = 60
 
   const reverseAnimation = () => {
-    const lower = animateRange.upper
-    const upper = animateRange.lower
-    setAnimateRange({ lower, upper })
+    const lower = range.upper
+    const upper = range.lower
+    setRange({ lower, upper })
   }
 
   // Hack to get IonRange knobs to show the correct position on component mount
   useEffect(() => {
     if (path === 'animation') {
       setTimeout(() => {
-        const old = Object.assign({}, animateRange)
-        setAnimateRange({ lower: 0, upper: 0 })
-        setAnimateRange(old)
+        const old = Object.assign({}, range)
+        setRange({ lower: 0, upper: 0 })
+        setRange(old)
       }, 100)
     }
   }, [path])
@@ -105,13 +86,6 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
   // background setting
   const [isBackgroundSettingEnable, setIsBackgroundSettingEnable] =
     useState(false)
-  // the isStarryBackgroundEnable and setIsStarryBackgroundEnable are moved to Main.tsx by Michael Chin
-  // const [isStarryBackgroundEnable, setIsStarryBackgroundEnable] = useState(false)
-  const [
-    isCustomisedColorBackgroundEnable,
-    setIsCustomisedColorBackgroundEnable,
-  ] = useState(false)
-  const [color, setColor] = useState({ r: 255, g: 255, b: 255 })
 
   const subPageRouting = (path: string, name: string) => {
     return (
@@ -147,7 +121,8 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
         <IonButtons slot={'end'}>
           <IonButton
             onClick={() => {
-              closeModal()
+              setIsShow(false)
+              setPath('root')
             }}
             color={'secondary'}
           >
@@ -228,12 +203,12 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
                 <IonRange
                   dir="rtl"
                   dualKnobs={true}
-                  min={minAge}
-                  max={maxAge}
+                  min={LIMIT_LOWER}
+                  max={LIMIT_UPPER}
                   onIonKnobMoveEnd={(e) => {
-                    setAnimateRange(e.detail.value as any)
+                    setRange(e.detail.value as any)
                   }}
-                  value={animateRange}
+                  value={range}
                 />
               </IonCol>
             </IonRow>
@@ -243,15 +218,15 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
                   <IonLabel>Animate from:</IonLabel>
                   <IonInput
                     inputMode="numeric"
-                    min={minAge}
-                    max={maxAge}
+                    min={LIMIT_LOWER}
+                    max={LIMIT_UPPER}
                     onIonChange={(e) =>
-                      setAnimateRange({
+                      setRange({
                         lower: Number(e.detail.value) || 0,
-                        upper: animateRange.upper,
+                        upper: range.upper,
                       } as any)
                     }
-                    value={animateRange.lower}
+                    value={range.lower}
                   />
                   Ma
                 </IonItem>
@@ -261,15 +236,15 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
                   <IonLabel>to:</IonLabel>
                   <IonInput
                     inputMode="numeric"
-                    min={minAge}
-                    max={maxAge}
+                    min={LIMIT_LOWER}
+                    max={LIMIT_UPPER}
                     onIonChange={(e) =>
-                      setAnimateRange({
-                        lower: animateRange.lower,
+                      setRange({
+                        lower: range.lower,
                         upper: Number(e.detail.value) || 0,
                       } as any)
                     }
-                    value={animateRange.upper}
+                    value={range.upper}
                   />
                   Ma
                 </IonItem>
@@ -333,15 +308,15 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
                 <IonItem>
                   <IonLabel>Finish animation exactly on end time</IonLabel>
                   <IonCheckbox
-                    checked={animateExact}
-                    onIonChange={(e) => setAnimateExact(e.detail.checked)}
+                    checked={exact}
+                    onIonChange={(e) => setExact(e.detail.checked)}
                   />
                 </IonItem>
                 <IonItem>
                   <IonLabel>Loop</IonLabel>
                   <IonCheckbox
-                    checked={animateLoop}
-                    onIonChange={(e) => setAnimateLoop(e.detail.checked)}
+                    checked={loop}
+                    onIonChange={(e) => setLoop(e.detail.checked)}
                   />
                 </IonItem>
               </IonCol>
@@ -359,16 +334,8 @@ export const SettingMenuPage: React.FC<ContainerProps> = ({
       >
         <BackgroundColorSettings
           viewer={viewer}
-          backgroundSetting={{
-            isBackgroundSettingEnable,
-            setIsBackgroundSettingEnable,
-            isStarryBackgroundEnable,
-            setIsStarryBackgroundEnable,
-            isCustomisedColorBackgroundEnable,
-            setIsCustomisedColorBackgroundEnable,
-            color,
-            setColor,
-          }}
+          isBackgroundSettingEnable={isBackgroundSettingEnable}
+          setIsBackgroundSettingEnable={setIsBackgroundSettingEnable}
         />
       </CSSTransition>
     </IonModal>


### PR DESCRIPTION
Hi @michaelchin, @yiyanw,

I'm working on saving app settings to local storage, and I thought it would be better if we could have our state in one place, so I've migrated us to a state management library called Recoil. It's an alternative to Redux (another popular library), developed by some people at Facebook (who also publish React).

It's quite powerful, and allows sharing state between components without passing props down the component tree (where it can get quite messy, and we might pass props through components that don't even need them) amongst other things we might find useful down the track. It's also pretty easy to pick up (useRecoilState() is almost a drop in replacement for useState(), for example).

Using Recoil should make the app more maintainable and perhaps more performant.

I'd recommend giving [the docs](https://recoiljs.org/docs/introduction/motivation) a look (mainly the introduction - it's a quick read).

Because this is a fundamental change that affects the whole project, I wanted to merge this early to avoid conflicts later. I tried to make sure I didn't break anything, but just to be sure, could you test your bits and make sure they still work? 

Apologies for the rather hefty commit, but there was no way around it - most of the changes should be fairly easy to review.

Thanks!

Time spent on issue: ~5hrs researching state management libraries, refactoring code, and testing.